### PR TITLE
Update HoneyBadger.md

### DIFF
--- a/IntroClassFiles/Tools/IntroClass/HoneyBadger.md
+++ b/IntroClassFiles/Tools/IntroClass/HoneyBadger.md
@@ -35,12 +35,12 @@ Usage
 In order to use the latest version of HoneyBadger, Python 3 must be installed, as well as python3-pip. These should both be installed on the ADHD image.
 
 Install HoneyBadger's required packages with the following command:
+`cd /opt/honeybadger/server`
 `pip3 install -r requirements.txt`
 
 NOTE: Only run the database initialization step if the database isn't already initialized.
 
 Next, initialize the database. To do so, navigate to the directory that contains the HoneyBadger files and run the Python interpreter:
-`cd /opt/honeybadger/server`
 `python3`
 
 From the python interpreter, run the following:
@@ -49,6 +49,7 @@ From the python interpreter, run the following:
     honeybadger.initdb('adhd', 'adhd')
 
 Quit the Python interpreter.
+`quit()`
 
 Finally, from the same directory, run the HoneyBadger server:
 `python3 honeybadger.py -ik <IPSTACK_KEY> -gk <GOOGLE_KEY>`


### PR DESCRIPTION
requirements.txt is in the /opt/honeybadger/server/ folder, the cd needs to be moved up before running the pip3 or it will fail.

Adding quit command to exit the python interpreter.

***NOT INCLUDED IN PULL, BUT NEEDS CLARIFICATION***  `python3 honeybadger.py -ik <IPSTACK_KEY> -gk <GOOGLE_KEY>`  on line 55 references keys that aren't included.  It may be that the instructions can include documentation on where to get the keys, or just removing the flags, since they aren't directly given for the course.